### PR TITLE
Use ESA dependency and features-bom

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -75,21 +75,25 @@
     	    <groupId>javax.xml.bind</groupId>
     	    <artifactId>jaxb-api</artifactId>
     	    <version>2.2.11</version>
+            <scope>test</scope>
     	</dependency>
     	<dependency>
     	    <groupId>com.sun.xml.bind</groupId>
     	    <artifactId>jaxb-core</artifactId>
     	    <version>2.2.11</version>
+            <scope>test</scope>
     	</dependency>
     	<dependency>
     	    <groupId>com.sun.xml.bind</groupId>
     	    <artifactId>jaxb-impl</artifactId>
     	    <version>2.2.11</version>
+            <scope>test</scope>
     	</dependency>
     	<dependency>
     	    <groupId>javax.activation</groupId>
     	    <artifactId>activation</artifactId>
     	    <version>1.1.1</version>
+            <scope>test</scope>
     	</dependency>
     </dependencies>
 

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -22,6 +22,18 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.openliberty.features</groupId>
+                <artifactId>features-bom</artifactId>
+                <version>18.0.0.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -48,21 +60,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.0.1</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jaxrs-2.0</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
-            <version>1.0.10</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.0</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jsonp-1.0</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
 	<dependency>

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -72,29 +72,29 @@
             <scope>provided</scope>
         </dependency>
     	<dependency>
-    	    <groupId>javax.xml.bind</groupId>
-    	    <artifactId>jaxb-api</artifactId>
-    	    <version>2.2.11</version>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
             <scope>test</scope>
-    	</dependency>
-    	<dependency>
-    	    <groupId>com.sun.xml.bind</groupId>
-    	    <artifactId>jaxb-core</artifactId>
-    	    <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
             <scope>test</scope>
-    	</dependency>
-    	<dependency>
-    	    <groupId>com.sun.xml.bind</groupId>
-    	    <artifactId>jaxb-impl</artifactId>
-    	    <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.2.11</version>
             <scope>test</scope>
-    	</dependency>
-    	<dependency>
-    	    <groupId>javax.activation</groupId>
-    	    <artifactId>activation</artifactId>
-    	    <version>1.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
             <scope>test</scope>
-    	</dependency>
+        </dependency>
     </dependencies>
 
     <build>

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>io.openliberty.features</groupId>
                 <artifactId>features-bom</artifactId>
-                <version>18.0.0.2</version>
+                <version>RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -71,26 +71,26 @@
             <type>esa</type>
             <scope>provided</scope>
         </dependency>
-	<dependency>
-	    <groupId>javax.xml.bind</groupId>
-	    <artifactId>jaxb-api</artifactId>
-	    <version>2.2.11</version>
-	</dependency>
-	<dependency>
-	    <groupId>com.sun.xml.bind</groupId>
-	    <artifactId>jaxb-core</artifactId>
-	    <version>2.2.11</version>
-	</dependency>
-	<dependency>
-	    <groupId>com.sun.xml.bind</groupId>
-	    <artifactId>jaxb-impl</artifactId>
-	    <version>2.2.11</version>
-	</dependency>
-	<dependency>
-	    <groupId>javax.activation</groupId>
-	    <artifactId>activation</artifactId>
-	    <version>1.1.1</version>
-	</dependency>
+    	<dependency>
+    	    <groupId>javax.xml.bind</groupId>
+    	    <artifactId>jaxb-api</artifactId>
+    	    <version>2.2.11</version>
+    	</dependency>
+    	<dependency>
+    	    <groupId>com.sun.xml.bind</groupId>
+    	    <artifactId>jaxb-core</artifactId>
+    	    <version>2.2.11</version>
+    	</dependency>
+    	<dependency>
+    	    <groupId>com.sun.xml.bind</groupId>
+    	    <artifactId>jaxb-impl</artifactId>
+    	    <version>2.2.11</version>
+    	</dependency>
+    	<dependency>
+    	    <groupId>javax.activation</groupId>
+    	    <artifactId>activation</artifactId>
+    	    <version>1.1.1</version>
+    	</dependency>
     </dependencies>
 
     <build>
@@ -126,11 +126,11 @@
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5</version>
                 <configuration>
                     <assemblyArtifact>
                          <groupId>io.openliberty</groupId>
-                         <artifactId>openliberty-runtime</artifactId>
+                         <artifactId>openliberty-kernel</artifactId>
                          <version>RELEASE</version>
                         <type>zip</type>
                     </assemblyArtifact>
@@ -152,6 +152,18 @@
                         <goals>
                             <goal>install-server</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>install-feature</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>install-feature</goal>
+                        </goals>
+                        <configuration>
+                            <features>
+                                <acceptLicense>true</acceptLicense>
+                            </features>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>install-app</id>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -73,21 +73,25 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
             <version>2.2.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>io.openliberty.features</groupId>
                 <artifactId>features-bom</artifactId>
-                <version>18.0.0.2</version>
+                <version>RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -124,11 +124,11 @@
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5</version>
                 <configuration>
                     <assemblyArtifact>
                          <groupId>io.openliberty</groupId>
-                         <artifactId>openliberty-runtime</artifactId>
+                         <artifactId>openliberty-kernel</artifactId>
                          <version>RELEASE</version>
                         <type>zip</type>
                     </assemblyArtifact>
@@ -148,6 +148,18 @@
                         <goals>
                             <goal>install-server</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>install-feature</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>install-feature</goal>
+                        </goals>
+                        <configuration>
+                            <features>
+                                <acceptLicense>true</acceptLicense>
+                            </features>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>install-app</id>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -20,6 +20,18 @@
         <packaging.type>usr</packaging.type>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.openliberty.features</groupId>
+                <artifactId>features-bom</artifactId>
+                <version>18.0.0.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -46,21 +58,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.0.1</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jaxrs-2.0</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
-            <version>1.0.10</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.0</version>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jsonp-1.0</artifactId>
+            <type>esa</type>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This pull request updates the project pom.xml file to replace all the dependencies with imported scope with the esa feature dependencies, and provides an alternative to use openliberty-kernel runtime with only the required features installed from the esa feature dependencies using the Liberty Maven plugin install-feature goal.

The esa feature dependency will automatically pull the feature's spec api, server api/spi dependencies for building the project.